### PR TITLE
update to leptos 0.6.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [dependencies.leptos]
 features = ["nightly"]
-version = "0.5.4"
+version = "0.6"
 
 [features]
 16-solid = []
@@ -1194,7 +1194,7 @@ license = "Apache-2.0 OR MIT"
 name = "leptos_heroicons"
 readme = "README.md"
 repository = "https://github.com/bbstilson/leptos_heroicons"
-version = "0.2.0"
+version = "0.3.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -1205,7 +1205,7 @@ members = ["example", "generate_components", "generate_example_components"]
 
 [workspace.dependencies.leptos]
 features = ["nightly"]
-version = "0.5.4"
+version = "0.6"
 
 [workspace.package]
 edition = "2021"


### PR DESCRIPTION
Updates leptos version to 0.6.x. Actually no other changes required.