### PR TITLE
Update to leptos 0.8.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [dependencies.leptos]
-version = "0.7"
+version = "0.8"
 
 [features]
 16-solid = []
@@ -1305,7 +1305,7 @@ license = "Apache-2.0 OR MIT"
 name = "leptos_heroicons"
 readme = "README.md"
 repository = "https://github.com/bbstilson/leptos_heroicons"
-version = "0.4.1"
+version = "0.5.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -1315,7 +1315,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 members = ["example", "generate_components", "generate_example_components"]
 
 [workspace.dependencies.leptos]
-version = "0.7"
+version = "0.8"
 
 [workspace.package]
 edition = "2021"


### PR DESCRIPTION
Same as #6, but with [Update to leptos 0.8.x](https://github.com/bbstilson/leptos_heroicons/pull/7/commits/aa93b53755810026437fb27a50f1f468ccd61082) commit. Waiting on #6 to be merged first. 